### PR TITLE
treat magic methods differently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- For magic methods, such as `__init__`, `DCO011` code is now used.
+
 ## [v1.3.0] - 2023-11-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The plugin adds the following configurations to `flake8`:
 A few rules have been defined to allow for selective suppression:
 
 - `DCO010`: docstring missing on a function/ method/ class.
+- `DCO011`: docstring missing on a magic method.
 - `DCO020`: function/ method has one or more arguments and the docstring does
   not have an arguments section.
 - `DCO021`: function/ method with no arguments and the docstring has an
@@ -180,6 +181,27 @@ def foo():
 class FooClass:
     """Perform foo action."""
     def foo(self):
+        """Perform foo action."""
+```
+
+### Fix DCO011
+
+This linting rule is triggered by a magic method without a docstring. For
+example:
+
+```Python
+class FooClass:
+    """Perform foo action."""
+    def __init__(self):
+        pass
+```
+
+This example can be fixed by adding a docstring:
+
+```Python
+class FooClass:
+    """Perform foo action."""
+    def __init__(self):
         """Perform foo action."""
 ```
 

--- a/flake8_docstrings_complete/__init__.py
+++ b/flake8_docstrings_complete/__init__.py
@@ -18,6 +18,11 @@ DOCSTR_MISSING_MSG = (
     f"{DOCSTR_MISSING_CODE} docstring should be defined for a function/ method/ class"
     f"{MORE_INFO_BASE}{DOCSTR_MISSING_CODE.lower()}"
 )
+MAGIC_METHOD_DOCSTR_MISSING_CODE = f"{ERROR_CODE_PREFIX}011"
+MAGIC_METHOD_DOCSTR_MISSING_MSG = (
+    f"{MAGIC_METHOD_DOCSTR_MISSING_CODE} docstring should be defined for a magic method"
+    f"{MORE_INFO_BASE}{MAGIC_METHOD_DOCSTR_MISSING_CODE.lower()}"
+)
 RETURNS_SECTION_NOT_IN_DOCSTR_CODE = f"{ERROR_CODE_PREFIX}030"
 RETURNS_SECTION_NOT_IN_DOCSTR_MSG = (
     f"{RETURNS_SECTION_NOT_IN_DOCSTR_CODE} function/ method that returns a value should have the "
@@ -360,9 +365,14 @@ class Visitor(ast.NodeVisitor):
         if not self._skip_function(node=node):
             # Check docstring is defined
             if ast.get_docstring(node) is None:
+                docstr_missing_msg = (
+                    MAGIC_METHOD_DOCSTR_MISSING_MSG
+                    if node.name.startswith("__") and node.name.endswith("__")
+                    else DOCSTR_MISSING_MSG
+                )
                 self.problems.append(
                     types_.Problem(
-                        lineno=node.lineno, col_offset=node.col_offset, msg=DOCSTR_MISSING_MSG
+                        lineno=node.lineno, col_offset=node.col_offset, msg=docstr_missing_msg
                     )
                 )
 

--- a/tests/integration/test___init__.py
+++ b/tests/integration/test___init__.py
@@ -14,6 +14,7 @@ from flake8_docstrings_complete import (
     FIXTURE_DECORATOR_PATTERN_DEFAULT,
     FIXTURE_FILENAME_PATTERN_ARG_NAME,
     FIXTURE_FILENAME_PATTERN_DEFAULT,
+    MAGIC_METHOD_DOCSTR_MISSING_CODE,
     MULT_RETURNS_SECTIONS_IN_DOCSTR_CODE,
     MULT_YIELDS_SECTIONS_IN_DOCSTR_CODE,
     RETURNS_SECTION_IN_DOCSTR_CODE,
@@ -166,6 +167,17 @@ def foo():  # noqa: {DOCSTR_MISSING_CODE}
             "source.py",
             "",
             id=f"{DOCSTR_MISSING_CODE} disabled",
+        ),
+        pytest.param(
+            f'''
+class Foo:
+    """Docstring."""
+    def __init__():  # noqa: {MAGIC_METHOD_DOCSTR_MISSING_CODE}
+        pass
+''',
+            "source.py",
+            "",
+            id=f"{MAGIC_METHOD_DOCSTR_MISSING_CODE} disabled",
         ),
         pytest.param(
             f'''

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -6,6 +6,7 @@ import pytest
 
 from flake8_docstrings_complete import (
     DOCSTR_MISSING_MSG,
+    MAGIC_METHOD_DOCSTR_MISSING_MSG,
     MULT_RETURNS_SECTIONS_IN_DOCSTR_MSG,
     MULT_YIELDS_SECTIONS_IN_DOCSTR_MSG,
     RETURNS_SECTION_IN_DOCSTR_MSG,
@@ -28,6 +29,14 @@ def function_1():
 """,
             (f"2:0 {DOCSTR_MISSING_MSG}",),
             id="function docstring missing return",
+        ),
+        pytest.param(
+            """
+def __function_1__():
+    return
+""",
+            (f"2:0 {MAGIC_METHOD_DOCSTR_MISSING_MSG}",),
+            id="magic function docstring missing return",
         ),
         pytest.param(
             """
@@ -487,6 +496,16 @@ class Class1:
 ''',
             (f"4:4 {DOCSTR_MISSING_MSG}",),
             id="method docstring missing return",
+        ),
+        pytest.param(
+            '''
+class Class1:
+    """Docstring."""
+    def __init__(self):
+        return
+''',
+            (f"4:4 {MAGIC_METHOD_DOCSTR_MISSING_MSG}",),
+            id="magic method docstring missing return",
         ),
         pytest.param(
             '''


### PR DESCRIPTION
Closes #15 

The reason this is targeted for `v2` is that it is a breaking change since any previous disables targeting `DCO010` for magic methods would no longer work. Given that this one is treated differently, the other error codes should also potentially be changed if they are for magic methods. They would need to be reviewed and added based on how it was done in this PR before `v2` should be released