### PR TITLE
Do not check private functions for args, returns or raises

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ discusses how to write great docstrings and the motivation for this linter!
 Following [PEP-8](https://peps.python.org/pep-0008/#documentation-strings),
 Docstrings are not necessary for non-public methods, but you should have a
 comment that describes what the method does. The definition taken for private
-is just a single `_`. This could be extended `__` see [name mangling](https://docs.python.org/3/tutorial/classes.html#private-variables).
+functions/methods is that they start with a single underscore (`_`).
 
 
 ## Getting Started
@@ -1678,3 +1678,6 @@ Section information is extracted using the following algorithm:
 - Check that argument, exceptions and attributes have non-empty description.
 - Check that arguments, exceptions and attributes have meaningful descriptions.
 - Check other other PEP257 conventions
+- The definition for private functions is a function starting with a single `_`. This could be extended to functions starting with `__`
+  and not ending in `__`, that is functions with [name mangling](https://docs.python.org/3/tutorial/classes.html#private-variables)
+  but not [magic methods](https://docs.python.org/3/reference/datamodel.html#special-lookup).

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ assumes that the docstrings already pass `pydocstyle` checks. This
 [blog post](https://jdkandersson.com/2023/01/07/writing-great-docstrings-in-python/)
 discusses how to write great docstrings and the motivation for this linter!
 
+Following [PEP-8](https://peps.python.org/pep-0008/#documentation-strings),
+Docstrings are not necessary for non-public methods, but you should have a
+comment that describes what the method does. The definition taken for private
+is just a single `_`. This could be extended `__` see [name mangling](https://docs.python.org/3/tutorial/classes.html#private-variables).
+
+
 ## Getting Started
 
 ```shell

--- a/flake8_docstrings_complete/__init__.py
+++ b/flake8_docstrings_complete/__init__.py
@@ -53,6 +53,7 @@ MULT_YIELDS_SECTIONS_IN_DOCSTR_MSG = (
     f"{MORE_INFO_BASE}{MULT_YIELDS_SECTIONS_IN_DOCSTR_CODE.lower()}"
 )
 
+PRIVATE_FUNCTION_PATTERN = r"_[^_].*"
 TEST_FILENAME_PATTERN_ARG_NAME = "--docstrings-complete-test-filename-pattern"
 TEST_FILENAME_PATTERN_DEFAULT = r"test_.*\.py"
 TEST_FUNCTION_PATTERN_ARG_NAME = "--docstrings-complete-test-function-pattern"
@@ -366,11 +367,13 @@ class Visitor(ast.NodeVisitor):
                     )
                 )
 
+            is_private = bool(re.match(PRIVATE_FUNCTION_PATTERN, node.name))
             if (
                 node.body
                 and isinstance(node.body[0], ast.Expr)
                 and isinstance(node.body[0].value, ast.Constant)
                 and isinstance(node.body[0].value.value, str)
+                and not is_private
             ):
                 # Check args
                 docstr_info = docstring.parse(value=node.body[0].value.value)

--- a/flake8_docstrings_complete/args.py
+++ b/flake8_docstrings_complete/args.py
@@ -67,7 +67,10 @@ def _iter_args(args: ast.arguments) -> Iterator[ast.arg]:
 
 
 def check(
-    docstr_info: docstring.Docstring, docstr_node: ast.Constant, args: ast.arguments
+    docstr_info: docstring.Docstring,
+    docstr_node: ast.Constant,
+    args: ast.arguments,
+    is_private: bool,
 ) -> Iterator[types_.Problem]:
     """Check that all function/ method arguments are described in the docstring.
 
@@ -80,6 +83,7 @@ def check(
         docstr_info: Information about the docstring.
         docstr_node: The docstring node.
         args: The arguments of the function.
+        is_private: If the function for the docstring is private.
 
     Yields:
         All the problems with the arguments.
@@ -88,7 +92,7 @@ def check(
     all_used_args = list(arg for arg in all_args if not arg.arg.startswith(UNUSED_ARGS_PREFIX))
 
     # Check that args section is in docstring if function/ method has used arguments
-    if all_used_args and docstr_info.args is None:
+    if all_used_args and docstr_info.args is None and not is_private:
         yield types_.Problem(
             docstr_node.lineno, docstr_node.col_offset, ARGS_SECTION_NOT_IN_DOCSTR_MSG
         )

--- a/flake8_docstrings_complete/raises.py
+++ b/flake8_docstrings_complete/raises.py
@@ -85,7 +85,10 @@ def _get_exc_node(node: ast.Raise) -> types_.Node | None:
 
 
 def check(
-    docstr_info: docstring.Docstring, docstr_node: ast.Constant, raise_nodes: Iterable[ast.Raise]
+    docstr_info: docstring.Docstring,
+    docstr_node: ast.Constant,
+    raise_nodes: Iterable[ast.Raise],
+    is_private: bool,
 ) -> Iterator[types_.Problem]:
     """Check that all raised exceptions arguments are described in the docstring.
 
@@ -97,6 +100,7 @@ def check(
         docstr_info: Information about the docstring.
         docstr_node: The docstring node.
         raise_nodes: The raise nodes.
+        is_private: If the function for the docstring is private.
 
     Yields:
         All the problems with exceptions.
@@ -106,7 +110,7 @@ def check(
     all_raise_no_value = all(exc is None for exc in all_excs)
 
     # Check that raises section is in docstring if function/ method raises exceptions
-    if all_excs and docstr_info.raises is None:
+    if all_excs and docstr_info.raises is None and not is_private:
         yield types_.Problem(
             docstr_node.lineno, docstr_node.col_offset, RAISES_SECTION_NOT_IN_DOCSTR_MSG
         )

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -1,5 +1,8 @@
 """Unit tests for plugin except for args rules."""
 
+# The lines represent the number of test cases
+# pylint: disable=too-many-lines
+
 from __future__ import annotations
 
 import pytest
@@ -101,6 +104,17 @@ def function_1():
 ''',
             (f"3:4 {RETURNS_SECTION_IN_DOCSTR_MSG}",),
             id="function no return returns in docstring",
+        ),
+        pytest.param(
+            '''
+def _function_1():
+    """Docstring.
+
+    Returns:
+    """
+''',
+            (f"3:4 {RETURNS_SECTION_IN_DOCSTR_MSG}",),
+            id="private function no return returns in docstring",
         ),
         pytest.param(
             '''
@@ -401,6 +415,17 @@ def function_1():
         ),
         pytest.param(
             '''
+def _function_1():
+    """Docstring.
+
+    Yields:
+    """
+''',
+            (f"3:4 {YIELDS_SECTION_IN_DOCSTR_MSG}",),
+            id="private function no yield yields in docstring",
+        ),
+        pytest.param(
+            '''
 class Class1:
     """Docstring."""
     def function_1():
@@ -525,6 +550,18 @@ def function_1():
 ''',
             (),
             id="function return value docstring returns section",
+        ),
+        pytest.param(
+            '''
+def _function_1():
+    """Docstring 1.
+
+    Returns:
+    """
+    return 1
+''',
+            (),
+            id="private function return value docstring returns section",
         ),
         pytest.param(
             '''
@@ -692,6 +729,18 @@ def function_1():
 ''',
             (),
             id="function yield value docstring yields section",
+        ),
+        pytest.param(
+            '''
+def _function_1():
+    """Docstring 1.
+
+    Yields:
+    """
+    yield 1
+''',
+            (),
+            id="private function yield value docstring yields section",
         ),
         pytest.param(
             '''

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -31,6 +31,14 @@ def function_1():
         ),
         pytest.param(
             """
+def _function_1():
+    return
+""",
+            (f"2:0 {DOCSTR_MISSING_MSG}",),
+            id="private function docstring missing return",
+        ),
+        pytest.param(
+            """
 @overload
 def function_1():
     ...

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -258,6 +258,15 @@ def function_1():
         ),
         pytest.param(
             '''
+def _function_1():
+    """Docstring."""
+    yield 1
+''',
+            (),
+            id="private function single yield value yields not in docstring",
+        ),
+        pytest.param(
+            '''
 def function_1():
     """Docstring."""
     yield from tuple()

--- a/tests/unit/test___init__args.py
+++ b/tests/unit/test___init__args.py
@@ -54,6 +54,17 @@ def function_1():
         ),
         pytest.param(
             '''
+def _function_1():
+    """Docstring 1.
+
+    Args:
+    """
+''',
+            (f"3:4 {ARGS_SECTION_IN_DOCSTR_MSG}",),
+            id="private function has no args docstring args section",
+        ),
+        pytest.param(
+            '''
 def function_1(arg_1):
     """Docstring 1.
 
@@ -462,6 +473,18 @@ def function_1(arg_1):
         ),
         pytest.param(
             '''
+def _function_1(arg_1):
+    """Docstring 1.
+
+    Args:
+        arg_1:
+    """
+''',
+            (),
+            id="private function single arg docstring single arg",
+        ),
+        pytest.param(
+            '''
 def function_1(_arg_1):
     """Docstring 1.
 
@@ -478,7 +501,7 @@ def _function_1(arg_1):
     """Docstring 1."""
 ''',
             (),
-            id="prive function single arg docstring no arg",
+            id="private function single arg docstring no arg",
         ),
         pytest.param(
             '''

--- a/tests/unit/test___init__args.py
+++ b/tests/unit/test___init__args.py
@@ -474,6 +474,14 @@ def function_1(_arg_1):
         ),
         pytest.param(
             '''
+def _function_1(arg_1):
+    """Docstring 1."""
+''',
+            (),
+            id="prive function single arg docstring no arg",
+        ),
+        pytest.param(
+            '''
 def function_1(_arg_1):
     """Docstring 1."""
 ''',

--- a/tests/unit/test___init__raises.py
+++ b/tests/unit/test___init__raises.py
@@ -67,6 +67,17 @@ def function_1():
         ),
         pytest.param(
             '''
+def _function_1():
+    """Docstring 1.
+
+    Raises:
+    """
+''',
+            (f"3:4 {RAISES_SECTION_IN_DOCSTR_MSG}",),
+            id="private function raises no exc docstring raises section",
+        ),
+        pytest.param(
+            '''
 def function_1():
     """Docstring 1.
 
@@ -486,6 +497,19 @@ def function_1():
 ''',
             (),
             id="function single raise no exc docstring raises exc",
+        ),
+        pytest.param(
+            '''
+def _function_1():
+    """Docstring 1.
+
+    Raises:
+      Exc1:
+    """
+    raise
+''',
+            (),
+            id="private function single raise no exc docstring raises exc",
         ),
         pytest.param(
             '''

--- a/tests/unit/test___init__raises.py
+++ b/tests/unit/test___init__raises.py
@@ -31,6 +31,15 @@ def function_1():
         ),
         pytest.param(
             '''
+def _function_1():
+    """Docstring 1."""
+    raise Exc1
+''',
+            (),
+            id="private function raises single exc docstring no raises section",
+        ),
+        pytest.param(
+            '''
 def function_1():
     """Docstring 1."""
     raise Exc1


### PR DESCRIPTION
This PR removes the check for args, returns and raises in private methods starting with `_`.

Following [PEP-8](https://peps.python.org/pep-0008/#documentation-strings), Docstrings are not necessary for non-public methods. The docstring is still necessary (following the `but you should have a comment that describes what the method does`).

This PR excluded the checks for private functions/methods (starting with `_`), but do not change the current process for functions starting with `__` (which are also private functions subject to [name mangling](https://docs.python.org/3/tutorial/classes.html#private-variables)). I have done that because those functions are not so common and also because `magic` functions also start with `__` (they also end with `__`, so we could differentiate them if necessary).
